### PR TITLE
Small code fix for HAPI

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,8 +19,10 @@ module.exports = class Realtime extends Trailpack {
   initialize () {
     return new Promise((res,rej)=>{
       this.app.once('webserver:http:ready',(httpServer)=>{
+        const relevantServer = _.has(httpServer, 'listener') ? httpServer.listener : httpServer
+
         const primusConfig = _.get(this.app.config,'realtime.primus',{options: {}})
-        this.app.sockets = new Primus(httpServer,Object.assign(primusDefaults,primusConfig.options))
+        this.app.sockets = new Primus(relevantServer, Object.assign(primusDefaults,primusConfig.options))
         res()
       })
     })

--- a/index.js
+++ b/index.js
@@ -19,10 +19,9 @@ module.exports = class Realtime extends Trailpack {
   initialize () {
     return new Promise((res,rej)=>{
       this.app.once('webserver:http:ready',(httpServer)=>{
-        const relevantServer = _.has(httpServer, 'listener') ? httpServer.listener : httpServer
 
         const primusConfig = _.get(this.app.config,'realtime.primus',{options: {}})
-        this.app.sockets = new Primus(relevantServer, Object.assign(primusDefaults,primusConfig.options))
+        this.app.sockets = new Primus(httpServer, Object.assign(primusDefaults,primusConfig.options))
         res()
       })
     })


### PR DESCRIPTION
Small code fix for when HAPI is being used as server engine in the Trails application to make Primus work with a HAPI server `httpServer.listener` needs to be passed instead of `httpServer` otherwise it won't work.

Relevant to ticket #6 
